### PR TITLE
Fixed two URLs for Ford reference VI documentation.

### DIFF
--- a/vehicle-interface/index.mkd
+++ b/vehicle-interface/index.mkd
@@ -77,8 +77,8 @@ hardware, and it connects to both the CAN1 and CAN2-1 [bus pins](#obd-pins) (and
 with a small modification can connect to CAN2-2).
 
 * [Reference VI Binary Firmware Programming
-  Instructions](http://vi.openxcplatform.com/firmware/programming/usb.html)
-* [Reference VI Documentation and Schematics](http://vi.openxcplatform.com/)
+  Instructions](http://vi-firmware.openxcplatform.com/en/latest/platforms/ford.html)
+* [Reference VI Documentation and Schematics](http://vi-firmware.openxcplatform.com/)
 
 <h2 id="cross-chasm"><a href="#cross-chasm">CrossChasm C5</a></h2>
 


### PR DESCRIPTION
Chris/Whom it may concern,

Found this tonight while trying to flash my reference VI. The two links both go no where. I fished out the vi-firmware URL's from knowing they were out there, and added the URL's that I think were trying to be pointed to. Adding this to the main branch as a bugfix
