### PR TITLE
Updated Android Library Installation page to point users to release page...

### DIFF
--- a/android/library-installation.mkd
+++ b/android/library-installation.mkd
@@ -2,7 +2,6 @@
 layout: developer
 title: Library Setup - OpenXC
 ---
-
 <div class="page-header">
     <h1>Android Library Installation</h1>
 </div>
@@ -47,21 +46,26 @@ If you use an Internet proxy, you will need to configure the proxy settings in
 the Android SDK manager (in `Tools -> Options`).
 </div>
 
-Get the [openxc-android][] source code in one of two ways:
+Get the [openxc-android][] source code in one of three ways:
 
-* *Recommended method:* Clone the [openxc-android][] repository using Git. If you
+* *Recommended method:* The latest stable version of the OpenXC Android source code
+can always be found [here](https://github.com/openxc/openxc-android/releases). 
+Make sure to download both the source code as well as the OpenXC Enabler App .apk. 
+The Vehicle Dashboard app is also available, which can be helpful in testing your Vehicle Interface. 
+Extract the files to the location where you'd like the library to sit on your local workstation.
+
+* Clone the [openxc-android][] repository using Git. If you
   don't already have Git installed, GitHub has a [good
   reference](https://help.github.com/articles/set-up-git) for all platforms.
-  This method is recommended because it makes it easier to keep up-to-date
-  with changes in the OpenXC library.
-* Download the latest version from [GitHub][openxc-android] as a ZIP file.
+  This method gets you the most up-to-date changes in the OpenXC library, but might not be as stable. 
+* You can also download the latest version from [GitHub][openxc-android] as a ZIP file.
   Look for the big ZIP icon like the example below).
 
 <a href="https://github.com/openxc/openxc-android">
 <img src="/images/screenshots/github.png" />
 </a>
 
-After cloning the `openxc-android` repository to your local disk, open Eclipse
+After obtaining the `openxc-android` library, open Eclipse
 and go to `File -> New -> Other -> Android -> Android Project from Existing
 Source`. Browse to the `openxc-android` folder and it should detect the 4
 Android projects within the repository. Unless you will be working on the
@@ -71,16 +75,13 @@ project. Click `Finish` to add the projects.
 ![Adding a Project in Eclipse](/images/screenshots/eclipse-import.png)
 
 Wait a few seconds for Eclipse to build the projects. If you get errors in the
-projects about a required compliance level, you can fix this by going to
-`Android Tools -> Fix Project Properties`. Otherwise, there should be no errors
+projects about a required compliance level, you can fix this by right-clicking on the errored project,
+then going to `Android Tools -> Fix Project Properties`. Otherwise, there should be no errors
 reported. You're ready to start working with OpenXC! If you still have errors,
 try asking in the [Google Group](/overview/discuss.html) for some help.
 
-Next up, you can start writing your [first OpenXC
-app](/android/tutorial.html).
-
 <div class="page-header">
-    <h3 id="cli"><a href="#cli">Using the Command Line</a></h3>
+    <h3 id="cli"><a href="#cli">Maven</a></h3>
 </div>
 
 If you prefer to compile and deploy from the command line, you can use
@@ -128,14 +129,12 @@ the `apklib` type is supported:
 </build>
 {% endhighlight %}
 
-Next up, you can start writing your [first OpenXC
-app](/android/tutorial.html).
 
 <div class="page-header">
-    <h3 id="enabler"><a href="#enabler">Enabler</a></h3>
+    <h2 id="enabler">Enabler</h2>
 </div>
 
-The best way to make the USB vehicle interface available to your app is to
+The best way to make the vehicle interface available to your app is to
 install the OpenXC Enabler app - the [source][enabler-source] for this app is in
 the [openxc-android][] repository.
 
@@ -157,8 +156,8 @@ There are three recommended ways to install the Enabler:
 
 **APK**
 
-The latest version of the Enabler is available as an [APK][], ready to install in
-Android.
+The latest version of the Enabler is available as an [APK][] on the Android Library
+Releases page, ready to install in Android.
 
 **Eclipse**
 
@@ -182,6 +181,6 @@ Once you have the library set up, you can start writing your [first OpenXC
 app](/android/tutorial.html). If you are having trouble, check out the
 [troubleshooting](/android/troubleshooting.html) steps.
 
-[APK]: https://s3.amazonaws.com/openxcplatform.com/openxc-enabler-v3.0.apk
+[APK]: https://github.com/openxc/openxc-android/releases
 [openxc-android]: https://github.com/openxc/openxc-android
 [enabler-source]: https://github.com/openxc/openxc-android/tree/master/enabler


### PR DESCRIPTION
... as well as changed Enabler Header to more clearly spell it out as it's own section which is separate from library installation.
