### PR TITLE
Document revisions

### DIFF
--- a/about/data-set.mkd
+++ b/about/data-set.mkd
@@ -142,4 +142,3 @@ unofficial mirror.
         vehicle, but if it's supported, try the steering wheel buttons.)
         <p><strong>Frequency:</strong> Sent only if value changes</p>
     </dd>
-</dl>

--- a/android/tutorial.mkd
+++ b/android/tutorial.mkd
@@ -15,7 +15,7 @@ documentation and tutorials - we won't repeat them here. The best place to start
 is [Android Studio's User Guide](https://developer.android.com/studio/intro/index.html).
 
 Once you're comfortable with creating an Android app, continue on with this
-tutorial to enrich it with data from your vehicle. 
+tutorial to enrich it with data from your vehicle.
 
 <div class="alert alert-danger"> We'll mention this again at the end of the
 tutorial, but you will need to install the
@@ -33,7 +33,7 @@ before your application will work.</div>
 1. Open the project with Android Studio.
 1. This project is ready to go, so if you want to quickly see something running
    jump ahead to the [testing section](#testing). To know more about how this
-   application works or to add the necessary code to a different app, continue 
+   application works or to add the necessary code to a different app, continue
    reading.
 
 <div class="page-header">
@@ -46,7 +46,7 @@ we've specified that the Starter app will use the OpenXC library as a
 dependency.
 
 This is already done in the Starter project and no changes have to be made. But to make your own app from scratch, go
-to the `app/build.gradle` file and add the `openxc` library to the build 
+to the `app/build.gradle` file and add the `openxc` library to the build
 dependencies. This is mentioned in the [Android Library Setup][library project]
 page:
 
@@ -54,7 +54,7 @@ page:
         compile 'com.openxcplatform:library:6.1.6+'
     }
 
-You can now proceed to the next steps to start using the library in your 
+You can now proceed to the next steps to start using the library in your
 project.
 
 <div class="page-header">
@@ -101,7 +101,7 @@ This should go between the `<application>` tags, like this:
 
 The next changes are all in Java code - for the Starter app, it's in
 `StarterActivity.java` in the `src` folder. In order to use the `VehicleManager`
-in Java code, we have to initiate the our `mVehicleManager` variable and then 
+in Java code, we have to initiate the our `mVehicleManager` variable and then
 bind with it when the application starts.
 
 Initiate our Starter App variables as shown here:
@@ -117,14 +117,14 @@ Initiate our Starter App variables as shown here:
         protected void onCreate(Bundle savedInstanceState) {
 {% endhighlight %}
 
-Then add the ServiceConnection in the `StarterActivity` to bind with the 
+Then add the ServiceConnection in the `StarterActivity` to bind with the
 VehicleManager:
 
 {% highlight java %}
     private ServiceConnection mConnection = new ServiceConnection() {
         // Called when the connection with the VehicleManager service is established
         public void onServiceConnected(ComponentName className, IBinder service) {
-            Log.i("openxc", "Bound to VehicleManager");
+            Log.i(TAG, "Bound to VehicleManager");
             // When the VehicleManager starts up, we store a reference to it
             // here in "mVehicleManager" so we can call functions on it
             // elsewhere in our code.
@@ -140,7 +140,7 @@ VehicleManager:
 
         // Called when the connection with the service disconnects unexpectedly
         public void onServiceDisconnected(ComponentName className) {
-            Log.w("openxc", "VehicleManager Service  disconnected unexpectedly");
+            Log.w(TAG, "VehicleManager Service  disconnected unexpectedly");
             mVehicleManager = null;
         }
     };

--- a/android/tutorial.mkd
+++ b/android/tutorial.mkd
@@ -62,7 +62,7 @@ project.
 </div>
 
 The `AndroidManifest.xml` is the core of every Android application - it tells
-the Android OS what views are available, which servies and used and what sensors
+the Android OS what views are available, which services are used and what sensors
 your app needs.
 
 Every OpenXC application, the Starter app included, needs to use the

--- a/hardware/vehicles.mkd
+++ b/hardware/vehicles.mkd
@@ -14,11 +14,14 @@ open source OBD-II OpenXC firmware. You can download the latest compiled
 version of that firmware from the [vi-firmware releases
 page](https://github.com/openxc/vi-firmware/releases).
 
-Grab the `openxc-obd2-firmware-*.zip` file for the latest version, which
+Grab the `vi-translated_obd2-firmware-*.hex` file for the latest version, which
 contains the OBD-II firmware for each of the supported vehicle interfaces.
 
+If you do not want the VI to translate the OBD-II messages for you and you want
+to send your own requests, grab the `vi-obd2-firmware-*.hex` instead.
+
 Next, look up the instructions for uploading the firmware to your vehicle
-interface on the 
+interface on the
 [supported VI hardware page](/vehicle-interface/hardware.html) - it's different for each
 type of VI.
 

--- a/hardware/vehicles.mkd
+++ b/hardware/vehicles.mkd
@@ -12,14 +12,15 @@ title: Supported Vehicles - OpenXC
 To read standard OBD-II diagnostics data from a car with OBD-II on CAN, use the
 open source OBD-II OpenXC firmware. You can download the latest compiled
 version of that firmware from the [vi-firmware releases
-page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}.
+page](https://github.com/openxc/vi-firmware/releases).
 
 Grab the `openxc-obd2-firmware-*.zip` file for the latest version, which
 contains the OBD-II firmware for each of the supported vehicle interfaces.
 
 Next, look up the instructions for uploading the firmware to your vehicle
-interface on the [supported VI hardware page](/vehicle-interface/hardware.html)
-- it's different for each.
+interface on the 
+[supported VI hardware page](/vehicle-interface/hardware.html) - it's different for each
+type of VI.
 
 ## Ford
 

--- a/overview/faq.mkd
+++ b/overview/faq.mkd
@@ -19,7 +19,7 @@ first stop.
 <p>If you wish to use Ford's expanded data set,
 you will need to sign a developer agreement to get access to the <a
 href="/hardware/vehicles.html">binary vehicle interface firmware</a>.
-</p></dd>
+</p>
 
 <dt>Why not just use one of the many commercial OBD-II scanners instead of
 OpenXC?</dt>
@@ -130,6 +130,3 @@ applications, it could be more vulnerable to reverse engineering. The strict
 physical separation of translation from user code provides stronger assurance
 that the message definitions will remain private, and the CAN bus will be
 protected from malicious writes from bad applications.</dd>
-
-
-</dl>

--- a/privacy.mkd
+++ b/privacy.mkd
@@ -24,7 +24,7 @@ terms of this privacy statement.
 ### 2. Information About Our Organization and Website:
 
 This Privacy Statement applies to openxcplatform.com. openxcplatform.com is
-owned by Ford Motor Company, Suite 225, 400 Hamilton Ave., Palo Alto, CA 94301.
+owned by Ford Motor Company, 3200 Hillview Avenue, Palo Alto CA 94304.
 
 The business purpose of this website is to provide developers reference
 materials and documentation, and the ability to download source code and the
@@ -209,8 +209,8 @@ openxc@ford.com
 **Mailing Address:**
 
 Ford Motor Company
-400 Hamilton Ave, Suite 225
-Palo Alto, CA 94301
+3200 Hillview Avenue
+Palo Alto CA 94304
 
 so that we may be able to process your changes. openxcplatform.com will use
 reasonable efforts to correct any factual inaccuracies in your information.
@@ -278,8 +278,8 @@ openxc@ford.com
 **Mailing Address**
 <address>
 Ford Motor Company
-400 Hamilton Ave, Suite 225
-Palo Alto, CA 94301
+3200 Hillview Avenue
+Palo Alto CA 94304
 </address>
 
 openxcplatform.com is committed to working with consumers to obtain a fair and

--- a/python/getting-started.mkd
+++ b/python/getting-started.mkd
@@ -27,21 +27,21 @@ can use a laptop to test.
 
 1. [Install the OpenXC Python
    library](http://python.openxcplatform.com/#installation) - don't forget the
-   [USB backend](http://python.openxcplatform.com/en/latest/#usb) if you want to
+   [USB backend](http://python.openxcplatform.com/en/latest/installation.html?highlight=usb%20backend#usb-backend) if you want to
    connect to the VI via USB and not Bluetooth.
-1. Attach the programmed VI to your computer with a USB cable, or pair with it
+2. Attach the programmed VI to your computer with a USB cable, or pair with it
    via Bluetooth and open a serial terminal (the Bluetooth pairing process
    depends on your platform, so we leave that as an exercise for the user). On
    Windows, install the driver from the [vi-firmware
    repository](https://github.com/openxc/vi-windows-driver).
-1. Run `openxc-control version` from the command line - it should print out the
+3. Run `openxc-control version` from the command line - it should print out the
    current version of the attached vehicle interface. If you instead get an
    error about not being able to find the USB device, make sure the VI has
    power (look for an LED).
    1. Did you get an error that there is `no backend available`? Go back to the
       Python library docs and make sure you [installed a USB
-      backend](http://python.openxcplatform.com/#usb).
-1. If the version check was successful, plug your VI into a running car and run
+      backend](http://python.openxcplatform.com/en/latest/installation.html?highlight=usb%20backend#usb-backend).
+4. If the version check was successful, plug your VI into a running car and run
    `openxc-dump` to test that data can be streamed from the vehicle interface.
    It should return a stream of live vehicle data, and `openxc-dashboard` will
    show the vehicle parameters in a useful windowed display.

--- a/python/getting-started.mkd
+++ b/python/getting-started.mkd
@@ -27,7 +27,7 @@ can use a laptop to test.
 
 1. [Install the OpenXC Python
    library](http://python.openxcplatform.com/#installation) - don't forget the
-   [USB backend](http://python.openxcplatform.com/en/latest/installation.html?highlight=usb%20backend#usb-backend) if you want to
+   [USB backend](http://python.openxcplatform.com/en/latest/installation.html#usb-backend) if you want to
    connect to the VI via USB and not Bluetooth.
 2. Attach the programmed VI to your computer with a USB cable, or pair with it
    via Bluetooth and open a serial terminal (the Bluetooth pairing process
@@ -40,7 +40,7 @@ can use a laptop to test.
    power (look for an LED).
    1. Did you get an error that there is `no backend available`? Go back to the
       Python library docs and make sure you [installed a USB
-      backend](http://python.openxcplatform.com/en/latest/installation.html?highlight=usb%20backend#usb-backend).
+      backend](http://python.openxcplatform.com/en/latest/installation.html#usb-backend).
 4. If the version check was successful, plug your VI into a running car and run
    `openxc-dump` to test that data can be streamed from the vehicle interface.
    It should return a stream of live vehicle data, and `openxc-dashboard` will

--- a/python/utilities.mkd
+++ b/python/utilities.mkd
@@ -30,7 +30,7 @@ $ openxc-dump
 ...
 
 # Send an OBD-II diagnostic request
-$ openxc-diag --message-id 0x7df --mode 0x3
+$ openxc-diag --message 0x7df --mode 0x3
 ...
 {% endhighlight %}
 

--- a/vehicle-interface/concepts.mkd
+++ b/vehicle-interface/concepts.mkd
@@ -7,7 +7,7 @@ title: Vehicle Interface Concepts - OpenXC
 <h1>VI Concepts</h1>
 </div>
 
-The <a href="/vehicle-interface/index.html">**vehicle interface (VI)**</a> is a
+The <a href="/vehicle-interface/index.html">vehicle interface (VI)</a> is a
 device that plugs into the OBD-II port (and thus to the CAN bus), reads and
 translates OBD-II requests and CAN messages into a [standard cross-vehicle
 format](https://github.com/openxc/openxc-message-format). The translated
@@ -24,7 +24,7 @@ or smartphone.
     </div>
 </div>
 
-The <a href="/host-devices/index.html">**host device**</a> connects to the
+The <a href="/host-devices/index.html">host device</a> connects to the
 vehicle interface and reads the translated vehicle data (e.g. an Android tablet
 or Python environment on a laptop). OpenXC developers can write applications on
 this device using the data.

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -7,15 +7,36 @@ title: VI Firmware - OpenXC
     <h1>Vehicle Interface Firmware</h1>
 </div>
 
-Before you can use a vehicle interface (VI), it has to be programmed with a
-firmware that understands data sent by your car. You have a few options:
+Before you can use a vehicle interface (VI), it <strong>must be programmed</strong>
+with a firmware that understands the data sent by your car. All of the below are
+available from the [vi-firmware releases page](https://github.com/openxc/vi-firmware/releases)
+or can be built on your own by following the
+[build configurations](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html#default-build).
+
+The following are the standard build configurations:
+
+**Default**
+
+Named "vi-<i>default</i>-firmware-PLATFORM-version.hex" in releases.
+
+These are built with the default compile options. It likely will not get
+data from your vehicle, but are used for some testing. It is a good check
+of your build environment.
 
 **On-board Diagnostics (OBD-II) Data from CAN**
 
-To read *standard OBD-II diagnostics data from a CAN bus*, use the open source
-OBD-II OpenXC firmware. You can download the latest compiled  version of that
-firmware from the [vi-firmware releases
-page](https://github.com/openxc/vi-firmware/releases){:target="_blank"} or view the [build configurations](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#default-build){:target="_blank"} if compiling directly from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"}. The OBD-II build will output a [subset of OBD-II data](https://github.com/openxc/vi-firmware/blob/next/src/obd2.cpp#L41){:target="_blank"} that
+Named "vi-<i>obd2</i>-firmware-PLATFORM-version.hex" in releases.
+
+This firmware is ready to received OBD2 requests over USB or Bluetooth (see the
+message format: https://github.com/openxc/openxc-message-format) but does *not*
+have any pre-defined recurring requests. You probably want this build if you are
+sending your own, custom diagnostic requests.
+
+**Translated OBD-II data from CAN**
+
+Named "vi-<i>translated-obd2</i>-firmware-PLATFORM-version.hex" in releases.
+
+The OBD-II build will output a [subset of OBD-II data](https://github.com/openxc/vi-firmware/blob/master/src/obd2.cpp#L39) that
 your car supports over USB and Bluetooth just like normal OpenXC data. Note that
 it's not much data - most likely only RPM, vehicle speed and intake manifold
 pressure. Your car must also support OBD-II via CAN, which is only required
@@ -24,23 +45,31 @@ your congressman if you want more!
 
 **Emulated Data**
 
+Named "vi-<i>emulator</i>-firmware-PLATFORM-version.hex" in releases.
+
 If you don't have access to a car and you want to verify the connection to the
 VI from your host device (or it's winter in Michigan and you'd just rather stay
-inside), you can use a simple emulator firmware. The emulator firmware will be a part of the firmware zip file that you will find on the [vi-firmware release page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. To compile your own emulated VI firmware from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"} you can use the [emulator build configuration](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#emulated-data-build){:target="_blank"} while compiling. It generates
+inside), you can use a simple emulator firmware. It generates
 fake vehicle data and continuously sends it over USB and Bluetooth as if it were
 live data. It's completely random data, so don't try and build an app against
-it.
+it. Also, the VI will NOT go to sleep with this firmware so don't leave it
+plugged into your vehicle, unless you want to drain the battery.
 
 **Expanded Proprietary Data**
 
+Available via download from [https://developer.ford.com](https://developer.ford.com),
+these provide vehicle specific CAN data.
+
 To read expanded data from a particular car, look for firmware distributed as
 pre-compiled binaries by your car's manufacturer. Check the [list of supported
-vehicles](http://openxcplatform.com/hardware/vehicles.html) for your car's make and model and for links
+vehicles](/hardware/vehicles.html) for your car's make and model and for links
 to download the firmware.
 
 **Flash the Firmware**
 
-If you have a Ford Reference VI, then follow these [instructions](http://vi.openxcplatform.com/firmware/programming/usb.html){:target="_blank"} to upload the firmware. For other versions of VIs, look up the instructions for uploading the
+If you have a Ford Reference VI, then follow these
+[instructions](http://vi.openxcplatform.com/firmware/programming/usb.html)
+to upload the firmware. For other versions of VIs, look up the instructions for uploading the
 firmware to your VI on the [supported VI hardware
 page](/vehicle-interface/hardware.html) - it's different for each.
 

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -28,9 +28,9 @@ of your build environment.
 Named "vi-<i>obd2</i>-firmware-PLATFORM-version.hex" in releases.
 
 This firmware is ready to received OBD2 requests over USB or Bluetooth (see the
-message format: https://github.com/openxc/openxc-message-format) but does *not*
-have any pre-defined recurring requests. You probably want this build if you are
-sending your own, custom diagnostic requests.
+[message format](https://github.com/openxc/openxc-message-format/blob/master/JSON.mkd#diagnostic-message)) 
+but does *not* have any pre-defined recurring requests. You probably want 
+this build if you are sending your own, custom diagnostic requests.
 
 **Translated OBD-II data from CAN**
 

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -26,7 +26,7 @@ your congressman if you want more!
 
 If you don't have access to a car and you want to verify the connection to the
 VI from your host device (or it's winter in Michigan and you'd just rather stay
-inside), you can use a simple emulator firmware. The emulator firmware will be a part of the firmware zip file that you will find on the [vi-firmware release page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. To compile your own vehicle interface firmware from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"} you can use the [emulator build configuration](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#emulated-data-build){:target="_blank"} to compile your code. It generates
+inside), you can use a simple emulator firmware. The emulator firmware will be a part of the firmware zip file that you will find on the [vi-firmware release page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. To compile your own emulated VI firmware from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"} you can use the [emulator build configuration](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#emulated-data-build){:target="_blank"} while compiling. It generates
 fake vehicle data and continuously sends it over USB and Bluetooth as if it were
 live data. It's completely random data, so don't try and build an app against
 it.
@@ -35,7 +35,7 @@ it.
 
 To read expanded data from a particular car, look for firmware distributed as
 pre-compiled binaries by your car's manufacturer. Check the [list of supported
-vehicles](/hardware/vehicles.html) for your car's make and model and for links
+vehicles](http://openxcplatform.com/hardware/vehicles.html) for your car's make and model and for links
 to download the firmware.
 
 **Flash the Firmware**

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -15,9 +15,7 @@ firmware that understands data sent by your car. You have a few options:
 To read *standard OBD-II diagnostics data from a CAN bus*, use the open source
 OBD-II OpenXC firmware. You can download the latest compiled  version of that
 firmware from the [vi-firmware releases
-page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. The OBD-II build will
-output a [subset of OBD-II
-data](https://github.com/openxc/vi-firmware/blob/next/src/obd2.cpp#L41){:target="_blank"} that
+page](https://github.com/openxc/vi-firmware/releases){:target="_blank"} or view the [build configurations](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#default-build){:target="_blank"} if compiling directly from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"}. The OBD-II build will output a [subset of OBD-II data](https://github.com/openxc/vi-firmware/blob/next/src/obd2.cpp#L41){:target="_blank"} that
 your car supports over USB and Bluetooth just like normal OpenXC data. Note that
 it's not much data - most likely only RPM, vehicle speed and intake manifold
 pressure. Your car must also support OBD-II via CAN, which is only required
@@ -28,8 +26,7 @@ your congressman if you want more!
 
 If you don't have access to a car and you want to verify the connection to the
 VI from your host device (or it's winter in Michigan and you'd just rather stay
-inside), you can use a simple emulator firmware. The emulator firmware will be a part of the firmware zip file that you will find on the [vi-firmware release
-page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. It generates
+inside), you can use a simple emulator firmware. The emulator firmware will be a part of the firmware zip file that you will find on the [vi-firmware release page](https://github.com/openxc/vi-firmware/releases){:target="_blank"}. To compile your own vehicle interface firmware from the [source code](https://github.com/openxc/vi-firmware){:target="_blank"} you can use the [emulator build configuration](http://vi-firmware.openxcplatform.com/en/master/compile/example-builds.html?highlight=translated%20obd2#emulated-data-build){:target="_blank"} to compile your code. It generates
 fake vehicle data and continuously sends it over USB and Bluetooth as if it were
 live data. It's completely random data, so don't try and build an app against
 it.
@@ -43,7 +40,7 @@ to download the firmware.
 
 **Flash the Firmware**
 
-If you have a Ford Reference VI, then follow these [instructions](http://vi.openxcplatform.com/firmware/programming/usb.html) to upload the firmware. For other versions of VIs, look up the instructions for uploading the
+If you have a Ford Reference VI, then follow these [instructions](http://vi.openxcplatform.com/firmware/programming/usb.html){:target="_blank"} to upload the firmware. For other versions of VIs, look up the instructions for uploading the
 firmware to your VI on the [supported VI hardware
 page](/vehicle-interface/hardware.html) - it's different for each.
 

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -35,7 +35,7 @@ it.
 
 To read expanded data from a particular car, look for firmware distributed as
 pre-compiled binaries by your car's manufacturer. Check the [list of supported
-vehicles](http://openxcplatform.com/hardware/vehicles.html) for your car's make and model and for links
+vehicles](/hardware/vehicles.html) for your car's make and model and for links
 to download the firmware.
 
 **Flash the Firmware**

--- a/vehicle-interface/firmware.mkd
+++ b/vehicle-interface/firmware.mkd
@@ -45,8 +45,7 @@ to download the firmware.
 
 If you have a Ford Reference VI, then follow these [instructions](http://vi.openxcplatform.com/firmware/programming/usb.html) to upload the firmware. For other versions of VIs, look up the instructions for uploading the
 firmware to your VI on the [supported VI hardware
-page](/vehicle-interface/hardware.html)
-- it's different for each.
+page](/vehicle-interface/hardware.html) - it's different for each.
 
 
 <div class="page-header">

--- a/vehicle-interface/hardware.mkd
+++ b/vehicle-interface/hardware.mkd
@@ -23,7 +23,7 @@ automakers expose other buses on additional, non-standard pin pairs. For this
 documentation, we'll use this nomenclature:
 
 <div class="well">
-<table>
+<table cellpadding="5">
 <thead>
 <tr><th>OBD-II Pin Pair</th><th>OpenXC Bus Name</th><th>Other common name</th></tr>
 </thead>
@@ -39,9 +39,12 @@ documentation, we'll use this nomenclature:
     <td>Ford secondary, Chrysler CCD</td>
 </tr>
 <tr>
-    <td>1 (+) and 9 (-)</td>
+    <td>1 (+) and 8/9 (-)*</td>
     <td>CAN2-2</td>
     <td>Ford: infotainment, GM: J2411</td>
+</tr>
+<tr>
+    <td colspan="3">* If available, Pin 8 on Ford B, C platforms and Pin 9 on Ford D platforms. This is typically not available. </td>
 </tr>
 </tbody>
 </table>

--- a/vehicle-interface/hardware.mkd
+++ b/vehicle-interface/hardware.mkd
@@ -39,7 +39,7 @@ documentation, we'll use this nomenclature:
     <td>Ford secondary, Chrysler CCD</td>
 </tr>
 <tr>
-    <td>1 (+) and 8 (-)</td>
+    <td>1 (+) and 9 (-)</td>
     <td>CAN2-2</td>
     <td>Ford: infotainment, GM: J2411</td>
 </tr>


### PR DESCRIPTION
- Updated power switch to 6A from 5A on vi.openxcplatform.com/electrical/design/power.html
- Changed from pin 8 to 9 on openxcplatform.com/vehicle-interface/hardware.html
- "servies and" typo corrected to "services are" in openxcplatform.com/android/tutorial.html
- Fixed bad link to python usb on openxcplatform.com/python/getting-started.html